### PR TITLE
lldb-vscode has been renamed to lldb-dap in the LLVM project

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,17 +63,17 @@ fn initialize(params: InitializeParams) -> Result<()> {
     }
 
     let exits = PLUGIN_RPC
-        .execute_process(program.to_string(), vec!["lldb-vscode".to_string()])
+        .execute_process(program.to_string(), vec!["lldb-dap".to_string()])
         .map(|r| r.success)
         .unwrap_or(false);
     if !exits {
         PLUGIN_RPC.window_show_message(
             MessageType::ERROR,
-            "lldb-vscode couldn't be found, please install or configure the path".to_string(),
+            "lldb-dap (formerly lldb-vscode) couldn't be found, please install or configure the path".to_string(),
         );
         return Ok(());
     }
-    PLUGIN_RPC.register_debugger_type("lldb".to_string(), "lldb-vscode".to_string(), None)?;
+    PLUGIN_RPC.register_debugger_type("lldb".to_string(), "lldb-dap".to_string(), None)?;
 
     Ok(())
 }


### PR DESCRIPTION
Hello, 

I was trying to configure this plugin, and noticed that it couldn't find `lldb-vscode`, even though I had installed LLVM (via Homebrew on Mac). Turns out the binary was renamed a while ago ([Link](https://github.com/llvm/llvm-project/pull/69264)). 

I just renamed all instances of `lldb-vscode` to `lldb-dap`, and edited the error message to reflect the change. 

Feel free to disregard this and fix it yourself if I've done something wrong or missed an important detail, should only take a few seconds. 

Cheers,
Kian